### PR TITLE
Sync up webhook instructions in README with current Slack UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ You just need to follow the following steps to setup a channel.
 
  1. Create a channel you want to share with another team.
  2. Create an Incoming WebHook integration and select the channel you created.
- 3. Copy the Incoming WebHook token (you can find it in the left column
-    from the integration page).
+ 3. Copy the Incoming WebHook token from the URL Slack provides for the WebHook. The token is the last element of the URL, ie: ```https://hooks.slack.com/services/[NOT THIS]/[NOT THIS]/[THIS IS THE TOKEN]```
  4. Create a URL with the following format: ```http://slackline.herokuapp.com/bridge/?token=[TOKEN]&domain=[YOUR_SLACK_DOMAIN]``` send it to the person setting up the other team.
  5. The person setting up the other team will send you a similar
     URL with their domain and token, create an Outgoing WebHook with


### PR DESCRIPTION
The instruction text for getting a token for incoming webhooks was out of date with Slack's interface. Updated them with current info which I tested and works